### PR TITLE
fix: ts config and package update for fixing reference

### DIFF
--- a/src/boilerplate.ts
+++ b/src/boilerplate.ts
@@ -19,12 +19,19 @@ const defaultTSConfig = {
         "target": "ES5",
         "module": "commonjs",
         "lib": [
-            "es2015"
+            "es2015",
+            "DOM" // for use console
         ],
         "removeComments": false,
         "skipLibCheck": true,
-        "sourceMap": false
-    }
+        "sourceMap": false,
+        "esModuleInterop": true
+    },
+    "include": [
+        "scripts/**/*",  // typescripts
+        "node_modules/autojs-dev/types/auto.d.ts" // auto file types
+    ],
+    "exclude": []
 };
 
 const autojsConfig = {
@@ -93,6 +100,8 @@ function Boilerplate(name: string, isModule: boolean) {
         description: "A Auto.js Script Project.",
         devDependencies: {
             "autojs-dev": JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8')).version,
+            "ts-loader": JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8'))["dependencies"]["ts-loader"], // 如果需要使用node scripts，则新建项目里需要拥有ts-loader和url-loader
+            "url-loader": JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8'))["dependencies"]["url-loader"],
         },
         author: "",
         license: "GPL-3.0"

--- a/template/script.ejs
+++ b/template/script.ejs
@@ -1,5 +1,4 @@
 <script>
-/// <reference path="./node_modules/autojs-dev/types/autojs.d.ts" />
 
 <%=(module ? 'export' : '') %> class <%=name %> {
     constructor(){
@@ -14,4 +13,5 @@
 <% if(!module){ %>
     <%=name %>.main();
 <% } %>
+
 </script>

--- a/types/modules/global.d.ts
+++ b/types/modules/global.d.ts
@@ -26,3 +26,6 @@ declare function exit(): void;
 declare function random(): number;
 declare function random(min: number, max: number): number;
 
+// for url-loader load img
+declare module '*.png'
+declare module '*.jpg'


### PR DESCRIPTION
fix: use import img from 'a/b/c.png'

update: reference for url-loader

把reference去掉然后使用include引入 d.ts 的类型定义

"esModuleInterop": true 增加了这个选项以实现 import img from './a/b/c'

在生成项目里加了ts-loader和url-loader以实现npx autojs build等命令